### PR TITLE
14 fix implement height aware bottom sheet dismiss thresholds

### DIFF
--- a/src/app/components/bottom-sheet-modal/bottom-sheet-modal.component.spec.ts
+++ b/src/app/components/bottom-sheet-modal/bottom-sheet-modal.component.spec.ts
@@ -71,7 +71,7 @@ describe('BottomSheetModalComponent', () => {
     void promise;
   });
 
-  it('should dismiss when dragged down beyond threshold', () => {
+  it('should apply a 80px dismiss threshold for short sheets (<360px)', () => {
     fixture.detectChanges();
 
     const promise = bottomSheetService.open(DummyContentComponent);
@@ -80,20 +80,70 @@ describe('BottomSheetModalComponent', () => {
     vi.advanceTimersByTime(16);
     fixture.detectChanges();
 
-    const handle = fixture.nativeElement.querySelector('[data-testid="sheet"] .cursor-grab') as HTMLElement;
+    const sheetEl = fixture.nativeElement.querySelector('[data-testid="sheet"]') as HTMLElement;
+    vi.spyOn(sheetEl, 'getBoundingClientRect').mockReturnValue({ height: 200 } as DOMRect);
+
+    const handle = sheetEl.querySelector('.cursor-grab') as HTMLElement;
     handle.setPointerCapture = vi.fn();
 
+    // Snap back test (79px drag)
     handle.dispatchEvent(new PointerEvent('pointerdown', { clientY: 100, pointerId: 1, bubbles: true }));
-    fixture.detectChanges();
-
-    // Drag down 200px (threshold is 150px)
-    handle.dispatchEvent(new PointerEvent('pointermove', { clientY: 300, pointerId: 1, bubbles: true }));
-    fixture.detectChanges();
-
+    handle.dispatchEvent(new PointerEvent('pointermove', { clientY: 179, pointerId: 1, bubbles: true }));
     handle.dispatchEvent(new PointerEvent('pointerup', { pointerId: 1, bubbles: true }));
     fixture.detectChanges();
 
-    // Advance to allow closing animation to trigger dismiss
+    vi.advanceTimersByTime(250);
+    fixture.detectChanges();
+
+    expect(bottomSheetService.state().isOpen).toBe(true);
+
+    // Dismiss test (81px drag)
+    handle.dispatchEvent(new PointerEvent('pointerdown', { clientY: 100, pointerId: 1, bubbles: true }));
+    handle.dispatchEvent(new PointerEvent('pointermove', { clientY: 181, pointerId: 1, bubbles: true }));
+    handle.dispatchEvent(new PointerEvent('pointerup', { pointerId: 1, bubbles: true }));
+    fixture.detectChanges();
+
+    vi.advanceTimersByTime(250);
+    fixture.detectChanges();
+
+    expect(bottomSheetService.state().isOpen).toBe(false);
+
+    vi.advanceTimersByTime(350);
+    void promise;
+  });
+
+  it('should apply a 120px dismiss threshold for tall sheets (>=360px)', () => {
+    fixture.detectChanges();
+
+    const promise = bottomSheetService.open(DummyContentComponent);
+    fixture.detectChanges();
+    vi.advanceTimersByTime(16);
+    vi.advanceTimersByTime(16);
+    fixture.detectChanges();
+
+    const sheetEl = fixture.nativeElement.querySelector('[data-testid="sheet"]') as HTMLElement;
+    vi.spyOn(sheetEl, 'getBoundingClientRect').mockReturnValue({ height: 400 } as DOMRect);
+
+    const handle = sheetEl.querySelector('.cursor-grab') as HTMLElement;
+    handle.setPointerCapture = vi.fn();
+
+    // Snap back test (119px drag)
+    handle.dispatchEvent(new PointerEvent('pointerdown', { clientY: 100, pointerId: 1, bubbles: true }));
+    handle.dispatchEvent(new PointerEvent('pointermove', { clientY: 219, pointerId: 1, bubbles: true }));
+    handle.dispatchEvent(new PointerEvent('pointerup', { pointerId: 1, bubbles: true }));
+    fixture.detectChanges();
+
+    vi.advanceTimersByTime(250);
+    fixture.detectChanges();
+
+    expect(bottomSheetService.state().isOpen).toBe(true);
+
+    // Dismiss test (121px drag)
+    handle.dispatchEvent(new PointerEvent('pointerdown', { clientY: 100, pointerId: 1, bubbles: true }));
+    handle.dispatchEvent(new PointerEvent('pointermove', { clientY: 221, pointerId: 1, bubbles: true }));
+    handle.dispatchEvent(new PointerEvent('pointerup', { pointerId: 1, bubbles: true }));
+    fixture.detectChanges();
+
     vi.advanceTimersByTime(250);
     fixture.detectChanges();
 

--- a/src/app/components/bottom-sheet-modal/bottom-sheet-modal.component.ts
+++ b/src/app/components/bottom-sheet-modal/bottom-sheet-modal.component.ts
@@ -2,7 +2,9 @@ import { ChangeDetectionStrategy, Component, effect, inject, signal, Type } from
 import { NgComponentOutlet } from '@angular/common';
 import { BottomSheetService } from '../../services/bottom-sheet.service';
 
-const DRAG_DISMISS_THRESHOLD = 150;
+const SHEET_HEIGHT_THRESHOLD = 360;
+const SHORT_DISMISS_THRESHOLD = 80;
+const TALL_DISMISS_THRESHOLD = 120;
 
 /**
  * Global bottom sheet overlay host rendered once at the root level.
@@ -40,6 +42,7 @@ export class BottomSheetModalComponent {
   private currentTranslate = 0;
   private isDragging = false;
   private sheetEl: HTMLElement | null = null;
+  private dragDismissThreshold = TALL_DISMISS_THRESHOLD;
 
   constructor() {
     effect(() => {
@@ -74,6 +77,10 @@ export class BottomSheetModalComponent {
     const handleEl = event.currentTarget as HTMLElement;
     this.sheetEl = handleEl.closest('[data-testid="sheet"]') as HTMLElement;
     if (!this.sheetEl) return;
+
+    const height = this.sheetEl.getBoundingClientRect().height;
+    this.dragDismissThreshold = height < SHEET_HEIGHT_THRESHOLD ? SHORT_DISMISS_THRESHOLD : TALL_DISMISS_THRESHOLD;
+
     this.startY = event.clientY;
     this.isDragging = true;
     handleEl.setPointerCapture(event.pointerId);
@@ -94,7 +101,7 @@ export class BottomSheetModalComponent {
     const sheetEl = this.sheetEl;
     this.sheetEl = null;
 
-    if (this.currentTranslate > DRAG_DISMISS_THRESHOLD) {
+    if (this.currentTranslate >= this.dragDismissThreshold) {
       sheetEl.style.transition = 'transform 200ms ease-in';
       sheetEl.style.transform = 'translateY(100%)';
       setTimeout(() => {

--- a/src/app/components/list-selector-modal/list-selector-modal.component.html
+++ b/src/app/components/list-selector-modal/list-selector-modal.component.html
@@ -8,7 +8,7 @@
     ... search input here ...
   </div> -->
 
-  <div class="flex-1 overflow-y-auto overscroll-contain pb-6">
+  <div class="flex-1 overflow-y-auto overscroll-contain pt-4 pb-6">
     <div class="flex flex-col">
       @for (item of items; track item.id) {
         <button


### PR DESCRIPTION
This pull request updates the bottom sheet modal's drag-to-dismiss behavior to use different drag thresholds based on the sheet's height and adds comprehensive tests for these cases. It also includes a small UI spacing adjustment in the list selector modal.

**Bottom Sheet Modal Drag-to-Dismiss Improvements:**

* The drag-to-dismiss threshold is now dynamic: sheets shorter than 360px require an 80px drag to dismiss, while taller sheets require a 120px drag. This replaces the previous fixed 150px threshold. (`src/app/components/bottom-sheet-modal/bottom-sheet-modal.component.ts`) [[1]](diffhunk://#diff-123a2670be877376752b6afae9d45f09baca94129f38f535f17eadce4b181307L5-R7) [[2]](diffhunk://#diff-123a2670be877376752b6afae9d45f09baca94129f38f535f17eadce4b181307R45) [[3]](diffhunk://#diff-123a2670be877376752b6afae9d45f09baca94129f38f535f17eadce4b181307R80-R83) [[4]](diffhunk://#diff-123a2670be877376752b6afae9d45f09baca94129f38f535f17eadce4b181307L97-R104)
* Unit tests have been expanded to verify the new threshold logic for both short and tall sheets, including snap-back and dismiss scenarios. (`src/app/components/bottom-sheet-modal/bottom-sheet-modal.component.spec.ts`) [[1]](diffhunk://#diff-65ca0abc8afe77581b9bfe072f5b583df417f98de4401c7cd47400252aaecfc6L74-R74) [[2]](diffhunk://#diff-65ca0abc8afe77581b9bfe072f5b583df417f98de4401c7cd47400252aaecfc6L83-L96)

**UI Improvements:**

* Added top padding to the scrollable area in the list selector modal for better spacing. (`src/app/components/list-selector-modal/list-selector-modal.component.html`)