### PR TITLE
5 feat home screen dashboard trend visualization

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -67,6 +67,7 @@
         "test": {
           "builder": "@angular/build:unit-test",
           "options": {
+            "tsConfig": "tsconfig.spec.json",
             "setupFiles": ["src/test-setup.ts"]
           }
         },

--- a/src/app/components/add-course-modal/add-course-modal.component.html
+++ b/src/app/components/add-course-modal/add-course-modal.component.html
@@ -74,7 +74,7 @@
 
       <button
         type="submit"
-        class="flex items-center justify-center gap-1 px-4 py-2 rounded-lg bg-primary text-true-obsidian text-lg font-medium border-none outline-none h-14 active:scale-[0.98] transition-transform"
+        class="flex items-center justify-center gap-1 px-4 py-2 rounded-lg bg-primary text-onyx text-lg font-medium border-none outline-none h-14 active:scale-[0.98] transition-transform"
       >
         Save course and tee
       </button>

--- a/src/app/components/add-tee-modal/add-tee-modal.component.html
+++ b/src/app/components/add-tee-modal/add-tee-modal.component.html
@@ -57,7 +57,7 @@
 
       <button
         type="submit"
-        class="flex items-center justify-center gap-1 px-4 py-2 rounded-lg bg-primary text-true-obsidian text-lg font-medium border-none outline-none h-14 active:scale-[0.98] transition-transform"
+        class="flex items-center justify-center gap-1 px-4 py-2 rounded-lg bg-primary text-onyx text-lg font-medium border-none outline-none h-14 active:scale-[0.98] transition-transform"
       >
         Save tee
       </button>

--- a/src/app/components/edit-course-modal/edit-course-modal.component.html
+++ b/src/app/components/edit-course-modal/edit-course-modal.component.html
@@ -18,7 +18,7 @@
       <div class="flex flex-col gap-3 pt-2">
         <button
           type="submit"
-          class="w-full h-14 rounded-lg font-medium text-lg bg-primary text-true-obsidian border-none outline-none active:scale-[0.98] transition-transform flex items-center justify-center"
+          class="w-full h-14 rounded-lg font-medium text-lg bg-primary text-onyx border-none outline-none active:scale-[0.98] transition-transform flex items-center justify-center"
         >
           Save course
         </button>
@@ -26,7 +26,7 @@
         <button
           type="button"
           (click)="onDelete()"
-          class="w-full h-14 rounded-lg font-medium text-lg bg-onyx text-error-light border border-error-light outline-none active:scale-[0.98] transition-transform flex items-center justify-center"
+          class="w-full h-14 rounded-lg font-medium text-lg bg-carbon-black text-error-light border border-error-light outline-none active:scale-[0.98] transition-transform flex items-center justify-center"
         >
           Delete course
         </button>

--- a/src/app/components/edit-tee-modal/edit-tee-modal.component.html
+++ b/src/app/components/edit-tee-modal/edit-tee-modal.component.html
@@ -54,7 +54,7 @@
       <div class="flex flex-col gap-3 pt-2">
         <button
           type="submit"
-          class="w-full h-14 rounded-lg font-medium text-lg bg-primary text-true-obsidian border-none outline-none active:scale-[0.98] transition-transform flex items-center justify-center"
+          class="w-full h-14 rounded-lg font-medium text-lg bg-primary text-onyx border-none outline-none active:scale-[0.98] transition-transform flex items-center justify-center"
         >
           Save tee
         </button>

--- a/src/app/components/page-header/page-header.component.html
+++ b/src/app/components/page-header/page-header.component.html
@@ -1,0 +1,19 @@
+<header class="flex items-center justify-between px-4 py-3 pt-10 border-b border-borders shrink-0">
+  @if (backButton) {
+    <div class="flex items-center min-w-0">
+      <button
+        type="button"
+        (click)="goBack()"
+        aria-label="Back"
+        class="bg-transparent border-none outline-none mr-2 flex items-center justify-center p-2 -ml-2 rounded-full active:bg-surface transition-colors"
+      >
+        <ng-icon name="ionChevronBack" class="text-2xl" [color]="'var(--color-alabaster-grey)'"></ng-icon>
+      </button>
+      <h1 class="text-xl font-medium text-primary-font truncate m-0">{{ title }}</h1>
+    </div>
+  } @else {
+    <h1 class="text-2xl font-medium m-0">{{ title }}</h1>
+  }
+
+  <ng-content select="[action]"></ng-content>
+</header>

--- a/src/app/components/page-header/page-header.component.ts
+++ b/src/app/components/page-header/page-header.component.ts
@@ -1,0 +1,30 @@
+import { booleanAttribute, ChangeDetectionStrategy, Component, inject, Input } from '@angular/core';
+import { NgIcon } from '@ng-icons/core';
+import { NavigationHistoryService } from '../../services/navigation-history.service';
+
+/**
+ * Component representing a reusable page header.
+ */
+@Component({
+  selector: 'app-page-header',
+  standalone: true,
+  imports: [NgIcon],
+  templateUrl: './page-header.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class PageHeaderComponent {
+  private readonly navigationHistoryService = inject(NavigationHistoryService);
+
+  /** The title of the page header. */
+  @Input() title = '';
+
+  /** Whether to show a back button in the header. */
+  @Input({ transform: booleanAttribute }) backButton = false;
+
+  /**
+   * Navigates back to the previous page in history.
+   */
+  async goBack(): Promise<void> {
+    await this.navigationHistoryService.pop();
+  }
+}

--- a/src/app/components/pop-up/pop-up.component.html
+++ b/src/app/components/pop-up/pop-up.component.html
@@ -20,7 +20,7 @@
       }
       <button
         type="button"
-        class="flex-1 py-4 text-lg font-medium text-championship-gold outline-none active:bg-borders transition-colors"
+        class="flex-1 py-4 text-lg font-medium text-bright-amber outline-none active:bg-borders transition-colors"
         (click)="primaryAction.emit()"
       >
         {{ primaryButtonText }}

--- a/src/app/icons.provider.ts
+++ b/src/app/icons.provider.ts
@@ -11,6 +11,10 @@ import {
   ionCreate,
   ionCalendarClear,
   ionCheckmark,
+  ionCaretUp,
+  ionCaretDown,
+  ionArrowForward,
+  ionCaretForward,
 } from '@ng-icons/ionicons';
 
 export const iconsProvider: Provider[] = provideIcons({
@@ -24,4 +28,8 @@ export const iconsProvider: Provider[] = provideIcons({
   ionCreate,
   ionCalendarClear,
   ionCheckmark,
+  ionCaretUp,
+  ionCaretDown,
+  ionArrowForward,
+  ionCaretForward,
 });

--- a/src/app/pages/add-round/add-round.component.html
+++ b/src/app/pages/add-round/add-round.component.html
@@ -1,17 +1,5 @@
 <div class="relative flex flex-col h-full">
-  <header class="flex items-center justify-between px-4 py-3 pt-10 border-b border-borders shrink-0">
-    <div class="flex items-center min-w-0">
-      <button
-        type="button"
-        (click)="goBack()"
-        aria-label="Back"
-        class="bg-transparent border-none outline-none mr-2 flex items-center justify-center p-2 -ml-2 rounded-full active:bg-surface transition-colors"
-      >
-        <ng-icon name="ionChevronBack" class="text-2xl" [color]="'var(--color-warm-white-dim)'"></ng-icon>
-      </button>
-      <h1 class="text-xl font-medium text-primary-font truncate m-0">Add round</h1>
-    </div>
-  </header>
+  <app-page-header title="Add round" backButton></app-page-header>
 
   <main class="flex-1 overflow-y-auto">
     <div class="px-4 py-6 h-full">
@@ -47,7 +35,7 @@
               <ng-icon
                 name="ionChevronDown"
                 class="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-lg"
-                [color]="'var(--color-warm-white-dim)'"
+                [color]="'var(--color-alabaster-grey)'"
               ></ng-icon>
             </div>
           </section>
@@ -96,7 +84,7 @@
               <ng-icon
                 name="ionChevronDown"
                 class="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-lg"
-                [color]="roundForm.controls.teeId.disabled ? 'var(--color-borders)' : 'var(--color-warm-white-dim)'"
+                [color]="roundForm.controls.teeId.disabled ? 'var(--color-borders)' : 'var(--color-alabaster-grey)'"
               ></ng-icon>
             </div>
           </section>
@@ -118,7 +106,7 @@
               <ng-icon
                 name="ionCalendarClear"
                 class="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-lg"
-                [color]="'var(--color-warm-white-dim)'"
+                [color]="'var(--color-alabaster-grey)'"
               ></ng-icon>
             </button>
           </section>
@@ -143,7 +131,7 @@
             type="submit"
             class="w-full h-14 rounded-lg font-medium text-lg border-none outline-none active:scale-[0.98] transition-transform flex items-center justify-center"
             [class.bg-primary]="roundForm.valid && !isSaving"
-            [class.text-true-obsidian]="roundForm.valid && !isSaving"
+            [class.text-onyx]="roundForm.valid && !isSaving"
             [class.bg-borders]="!roundForm.valid || isSaving"
             [class.text-secondary-font]="!roundForm.valid || isSaving"
             [disabled]="isSaving"

--- a/src/app/pages/add-round/add-round.component.spec.ts
+++ b/src/app/pages/add-round/add-round.component.spec.ts
@@ -80,11 +80,6 @@ describe('AddRoundPage', () => {
     fixture.detectChanges();
   });
 
-  it('navigates back when goBack is called', async () => {
-    await component.goBack();
-    expect(navigationHistoryServiceMock.pop).toHaveBeenCalled();
-  });
-
   it('loads and sorts courses alphabetically', async () => {
     courseServiceMock.getCourses.mockResolvedValue([
       { id: '2', name: 'Zebra Course' },

--- a/src/app/pages/add-round/add-round.component.ts
+++ b/src/app/pages/add-round/add-round.component.ts
@@ -15,7 +15,7 @@ import { CourseService } from '../../services/course.service';
 import { HandicapStateService } from '../../services/handicap-state.service';
 import { RoundService } from '../../services/round.service';
 import { ToastService } from '../../services/toast.service';
-import { NavigationHistoryService } from '../../services/navigation-history.service';
+
 import { ValidationStatusDirective } from '../../directives/validation-status.directive';
 import {
   ListSelectorModalComponent,
@@ -23,6 +23,7 @@ import {
 } from '../../components/list-selector-modal/list-selector-modal.component';
 import { DatePickerComponent } from '../../components/date-picker/date-picker.component';
 import { PopUpComponent } from '../../components/pop-up/pop-up.component';
+import { PageHeaderComponent } from '../../components/page-header/page-header.component';
 
 interface RoundFormValue {
   courseId: string;
@@ -45,7 +46,7 @@ interface PendingRoundPayload {
   host: { class: 'block h-full' },
   templateUrl: './add-round.component.html',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, NgIcon, ValidationStatusDirective, PopUpComponent],
+  imports: [CommonModule, ReactiveFormsModule, NgIcon, ValidationStatusDirective, PopUpComponent, PageHeaderComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AddRoundPage implements OnInit {
@@ -57,7 +58,6 @@ export class AddRoundPage implements OnInit {
   private readonly fb = inject(FormBuilder);
   private readonly cdr = inject(ChangeDetectorRef);
   private readonly bottomSheetService = inject(BottomSheetService);
-  private readonly navigationHistoryService = inject(NavigationHistoryService);
 
   readonly todayIsoDate = this.getTodayIsoDate();
   readonly minGrossScore = ROUND_LIMITS.MIN_GROSS_SCORE;
@@ -86,13 +86,6 @@ export class AddRoundPage implements OnInit {
   duplicateSummary = '';
   private readonly dismissedValidationFields = new Set<keyof RoundFormValue>();
   private pendingRoundPayload: PendingRoundPayload | null = null;
-
-  /**
-   * Navigates back to the previous page in history.
-   */
-  async goBack(): Promise<void> {
-    await this.navigationHistoryService.pop();
-  }
 
   /**
    * Initializes the component.

--- a/src/app/pages/course-detail/course-detail.component.html
+++ b/src/app/pages/course-detail/course-detail.component.html
@@ -1,26 +1,16 @@
 <div class="flex flex-col h-full">
-  <header class="flex items-center justify-between px-4 py-3 pt-10 border-b border-borders shrink-0">
-    <div class="flex items-center min-w-0">
-      <button
-        type="button"
-        (click)="goBack()"
-        aria-label="Back"
-        class="bg-transparent border-none outline-none mr-2 flex items-center justify-center p-2 -ml-2 rounded-full active:bg-surface transition-colors"
-      >
-        <ng-icon name="ionChevronBack" class="text-2xl" [color]="'var(--color-warm-white-dim)'"></ng-icon>
-      </button>
-      <h1 class="text-xl font-medium text-primary-font truncate m-0">{{ course?.name || 'Course Details' }}</h1>
-    </div>
+  <app-page-header [title]="course?.name || 'Course Details'" backButton>
     <button
+      action
       type="button"
       (click)="openEditCourseModal()"
       title="Edit course"
       aria-label="Edit course"
       class="bg-transparent border-none outline-none p-2 -mr-2 active:bg-surface transition-colors flex items-center justify-center"
     >
-      <ng-icon name="ionCreate" class="text-2xl" [color]="'var(--color-warm-white-dim)'"></ng-icon>
+      <ng-icon name="ionCreate" class="text-2xl" [color]="'var(--color-alabaster-grey)'"></ng-icon>
     </button>
-  </header>
+  </app-page-header>
 
   <main class="flex-1 overflow-y-auto">
     @if (course) {
@@ -109,7 +99,7 @@
 
             <button
               type="submit"
-              class="mt-2 w-full h-14 rounded-lg font-medium text-lg bg-primary text-true-obsidian border-none outline-none active:scale-[0.98] transition-transform flex items-center justify-center"
+              class="mt-2 w-full h-14 rounded-lg font-medium text-lg bg-primary text-onyx border-none outline-none active:scale-[0.98] transition-transform flex items-center justify-center"
             >
               Save tee
             </button>

--- a/src/app/pages/course-detail/course-detail.component.spec.ts
+++ b/src/app/pages/course-detail/course-detail.component.spec.ts
@@ -89,13 +89,6 @@ describe('CourseDetailPage', () => {
     });
   });
 
-  describe('goBack', () => {
-    it('should call navigationHistoryService.pop()', async () => {
-      await component.goBack();
-      expect(navigationHistoryServiceMock.pop).toHaveBeenCalled();
-    });
-  });
-
   describe('ngOnInit', () => {
     it('should load course and tees on init based on route param', async () => {
       component.ngOnInit();

--- a/src/app/pages/course-detail/course-detail.component.ts
+++ b/src/app/pages/course-detail/course-detail.component.ts
@@ -2,10 +2,10 @@ import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject }
 import { ActivatedRoute, Router } from '@angular/router';
 import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
 import { NgIcon } from '@ng-icons/core';
+import { PageHeaderComponent } from '../../components/page-header/page-header.component';
 import { CourseService } from '../../services/course.service';
 import { ToastService } from '../../services/toast.service';
 import { BottomSheetService } from '../../services/bottom-sheet.service';
-import { NavigationHistoryService } from '../../services/navigation-history.service';
 import { Course, Tee } from '../../database/db';
 import { ValidationStatusDirective } from '../../directives/validation-status.directive';
 import { WHS_LIMITS } from '../../constants/whs.constants';
@@ -23,7 +23,7 @@ import { EditTeeModalComponent, EditTeeModalResult } from '../../components/edit
   host: { class: 'block h-full' },
   templateUrl: './course-detail.component.html',
   standalone: true,
-  imports: [ReactiveFormsModule, NgIcon, ValidationStatusDirective],
+  imports: [ReactiveFormsModule, NgIcon, ValidationStatusDirective, PageHeaderComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CourseDetailPage implements OnInit {
@@ -34,7 +34,6 @@ export class CourseDetailPage implements OnInit {
   private readonly cdr = inject(ChangeDetectorRef);
   private readonly toastService = inject(ToastService);
   private readonly bottomSheetService = inject(BottomSheetService);
-  private readonly navigationHistoryService = inject(NavigationHistoryService);
 
   courseId: string | null = null;
   course: Course | undefined;
@@ -50,13 +49,6 @@ export class CourseDetailPage implements OnInit {
       slope: ['', [Validators.required, Validators.min(WHS_LIMITS.MIN_SLOPE), Validators.max(WHS_LIMITS.MAX_SLOPE)]],
       par: ['', [Validators.required, Validators.min(1)]],
     });
-  }
-
-  /**
-   * Navigates back to the previous page in history.
-   */
-  async goBack() {
-    await this.navigationHistoryService.pop();
   }
 
   /**

--- a/src/app/pages/courses/courses.component.html
+++ b/src/app/pages/courses/courses.component.html
@@ -1,15 +1,15 @@
 <div class="flex flex-col h-full">
-  <header class="flex items-center justify-between px-4 py-3 pt-10 border-b border-borders shrink-0">
-    <h1 class="text-2xl font-medium m-0">Courses</h1>
+  <app-page-header title="Courses">
     <button
+      action
       type="button"
       (click)="openAddCourseModal()"
-      class="flex items-center justify-center gap-1 px-4 py-2 rounded-lg bg-primary text-true-obsidian text-lg font-medium border-none outline-none h-11 active:scale-[0.98] transition-transform"
+      class="flex items-center justify-center gap-1 px-4 py-2 rounded-lg bg-primary text-onyx text-lg font-medium border-none outline-none h-11 active:scale-[0.98] transition-transform"
     >
       <ng-icon name="ionAdd"></ng-icon>
       Add
     </button>
-  </header>
+  </app-page-header>
 
   <main class="flex-1 overflow-y-auto">
     <div class="px-4 py-6 h-full">
@@ -32,7 +32,7 @@
                   {{ course.teeCount }} {{ course.teeCount === 1 ? 'tee' : 'tees' }}
                 </p>
               </div>
-              <ng-icon name="ionChevronForward" [color]="'var(--color-warm-white-dim)'"></ng-icon>
+              <ng-icon name="ionChevronForward" [color]="'var(--color-alabaster-grey)'"></ng-icon>
             </a>
           }
         </div>

--- a/src/app/pages/courses/courses.component.ts
+++ b/src/app/pages/courses/courses.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject } from '@angular/core';
 import { RouterModule } from '@angular/router';
+import { PageHeaderComponent } from '../../components/page-header/page-header.component';
 import { NgIcon } from '@ng-icons/core';
 import { CourseService } from '../../services/course.service';
 import { ToastService } from '../../services/toast.service';
@@ -22,7 +23,7 @@ interface CourseWithTeeCount extends Course {
   host: { class: 'block h-full' },
   templateUrl: './courses.component.html',
   standalone: true,
-  imports: [RouterModule, NgIcon],
+  imports: [RouterModule, NgIcon, PageHeaderComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CoursesPage implements OnInit {

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -1,3 +1,132 @@
-<div class="p-4">
-  <h2>Home</h2>
+<div class="flex flex-col h-full">
+  <app-page-header title="MyNetScore"></app-page-header>
+
+  <main class="flex-1 flex flex-col px-4 pt-2 pb-6 overflow-hidden min-h-0">
+    <div class="flex flex-col items-center justify-center flex-1 min-h-[120px] py-4">
+      @if (totalRoundsInWindow() > 0 && handicapIndex() !== null) {
+        <div
+          class="text-[3.75rem] min-[380px]:text-[4.5rem] font-bold leading-none tracking-tight text-primary-font shrink-0"
+        >
+          {{ handicapIndex() | number: '1.1-1' }}
+        </div>
+        <div
+          class="text-secondary-font text-base min-[380px]:text-lg flex items-center gap-1 font-medium mt-1 shrink-0"
+        >
+          Handicap Index
+          @if (isProvisional()) {
+            <span class="text-secondary-font/70">(provisional)</span>
+          }
+        </div>
+      } @else {
+        <div
+          class="text-[3.75rem] min-[380px]:text-[4.5rem] font-bold leading-none tracking-tight text-primary-font opacity-50 shrink-0"
+        >
+          &mdash;
+        </div>
+        <div class="text-secondary-font text-base min-[380px]:text-lg font-medium mt-1 shrink-0">Handicap Index</div>
+      }
+
+      <div
+        class="h-6 mt-1 flex items-center justify-center text-sm min-[380px]:text-base font-semibold {{
+          trendDisplay().class
+        }} shrink-0"
+      >
+        @if (trend() !== 'none') {
+          @if (trendDisplay().icon) {
+            <ng-icon [name]="trendDisplay().icon!" class="mr-1"></ng-icon>
+          }
+          {{ trendDisplay().text }}
+        }
+      </div>
+    </div>
+
+    <div class="grid grid-cols-2 gap-3 min-[380px]:gap-4 shrink-0 py-4">
+      <div class="bg-surface rounded-2xl p-3 min-[380px]:p-4 flex flex-col items-center justify-center shadow-sm">
+        <span class="text-xl min-[380px]:text-2xl font-bold text-primary-font">{{ totalRounds() }}</span>
+        <span class="text-secondary-font text-xs min-[380px]:text-sm mt-1">Rounds</span>
+      </div>
+      <div class="bg-surface rounded-2xl p-3 min-[380px]:p-4 flex flex-col items-center justify-center shadow-sm">
+        <span class="text-xl min-[380px]:text-2xl font-bold text-primary-font">{{ totalCoursesPlayed() }}</span>
+        <span class="text-secondary-font text-xs min-[380px]:text-sm mt-1">Courses</span>
+      </div>
+    </div>
+
+    <div class="flex flex-col shrink-0 mb-4">
+      <div class="flex justify-between items-end px-1 mb-3">
+        <h3 class="text-xl font-medium text-primary-font m-0">Recent rounds</h3>
+        @if (recentRounds().length > 0) {
+          <a
+            routerLink="/rounds"
+            class="text-primary font-medium text-lg flex items-center gap-1 hover:opacity-80 transition-opacity no-underline"
+          >
+            See all <ng-icon name="ionArrowForward" class="text-sm"></ng-icon>
+          </a>
+        }
+      </div>
+
+      <div class="relative flex flex-col gap-2 min-[380px]:gap-3 shrink-0">
+        @if (recentRounds().length === 0) {
+          <div class="absolute inset-0 flex flex-col items-center justify-center z-10">
+            <h2 class="text-secondary-font">No rounds recorded</h2>
+          </div>
+        }
+
+        @for (round of recentRounds(); track round.id) {
+          <div
+            class="bg-surface rounded-2xl p-3 min-[380px]:p-4 flex items-center justify-between shadow-sm shrink-0 gap-2 relative z-20"
+          >
+            <div class="flex items-center gap-2 min-[380px]:gap-3 flex-1 min-w-0">
+              <div
+                class="w-2 h-2 rounded-full flex-shrink-0"
+                [class.bg-success]="isRoundCounting(round.id)"
+                [class.bg-transparent]="!isRoundCounting(round.id)"
+              ></div>
+              <div class="flex flex-col flex-1 min-w-0">
+                <span class="text-primary-font text-[0.95rem] min-[380px]:text-[1.05rem] truncate block">{{
+                  round.courseName
+                }}</span>
+                <span class="text-secondary-font text-xs min-[380px]:text-sm mt-0.5">{{
+                  round.date | date: 'd MMM' : 'UTC'
+                }}</span>
+              </div>
+            </div>
+            <div class="flex flex-col items-end flex-shrink-0">
+              <span class="text-primary-font text-[1rem] min-[380px]:text-[1.1rem]">{{ round.grossScore }}</span>
+              <span class="text-secondary-font text-xs min-[380px]:text-sm mt-0.5">{{
+                round.differential | number: '1.1-1'
+              }}</span>
+            </div>
+          </div>
+        }
+
+        @for (p of placeholders(); track $index) {
+          <div
+            class="bg-surface rounded-2xl p-3 min-[380px]:p-4 flex items-center justify-between shadow-sm shrink-0 gap-2 opacity-0 pointer-events-none select-none"
+            aria-hidden="true"
+          >
+            <div class="flex items-center gap-2 min-[380px]:gap-3 flex-1 min-w-0">
+              <div class="w-2 h-2 rounded-full flex-shrink-0"></div>
+              <div class="flex flex-col flex-1 min-w-0">
+                <span class="text-[0.95rem] min-[380px]:text-[1.05rem] block">&nbsp;</span>
+                <span class="text-xs min-[380px]:text-sm mt-0.5">&nbsp;</span>
+              </div>
+            </div>
+            <div class="flex flex-col items-end flex-shrink-0">
+              <span class="text-[1rem] min-[380px]:text-[1.1rem] block">&nbsp;</span>
+              <span class="text-xs min-[380px]:text-sm mt-0.5">&nbsp;</span>
+            </div>
+          </div>
+        }
+      </div>
+    </div>
+
+    <div class="shrink-0">
+      <a
+        routerLink="/rounds/add"
+        class="bg-primary text-onyx font-medium text-base min-[380px]:text-lg rounded-lg py-2.5 min-[380px]:py-3 flex items-center justify-center w-full shadow-lg active:scale-[0.98] transition-transform no-underline"
+      >
+        <ng-icon name="ionAdd" class="mr-1 text-lg min-[380px]:text-xl"></ng-icon> Add round
+      </a>
+    </div>
+  </main>
 </div>

--- a/src/app/pages/home/home.component.spec.ts
+++ b/src/app/pages/home/home.component.spec.ts
@@ -1,0 +1,136 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { HomePage } from './home.component';
+import { HandicapStateService, RecentRoundDisplay } from '../../services/handicap-state.service';
+import { provideIcons } from '@ng-icons/core';
+import { ionArrowForward, ionCaretDown, ionCaretUp, ionCaretForward, ionAdd } from '@ng-icons/ionicons';
+import { signal } from '@angular/core';
+
+describe('HomePage', () => {
+  let fixture: ComponentFixture<HomePage>;
+
+  const mockHandicapIndex = signal<number | null>(null);
+  const mockTotalRoundsInWindow = signal<number>(0);
+  const mockTotalRounds = signal<number>(0);
+  const mockTotalCoursesPlayed = signal<number>(0);
+  const mockTrend = signal<'improving' | 'worsening' | 'stable' | 'none'>('none');
+  const mockRecentRounds = signal<RecentRoundDisplay[]>([]);
+  const mockUsedRoundIds = signal<string[]>([]);
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HomePage],
+      providers: [
+        provideRouter([]),
+        provideIcons({ ionArrowForward, ionCaretDown, ionCaretUp, ionCaretForward, ionAdd }),
+        {
+          provide: HandicapStateService,
+          useValue: {
+            handicapIndex: mockHandicapIndex,
+            totalRoundsInWindow: mockTotalRoundsInWindow,
+            totalRounds: mockTotalRounds,
+            totalCoursesPlayed: mockTotalCoursesPlayed,
+            trend: mockTrend,
+            recentRounds: mockRecentRounds,
+            usedRoundIds: mockUsedRoundIds,
+            refresh: () => Promise.resolve(),
+          },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(HomePage);
+    fixture.detectChanges();
+  });
+
+  it('should render empty state when no rounds exist', () => {
+    const textContent = fixture.nativeElement.textContent;
+    expect(textContent).toContain('—');
+    expect(textContent).toContain('No rounds recorded');
+  });
+
+  it('should display provisional status and values when rounds < 20', () => {
+    mockHandicapIndex.set(12.4);
+    mockTotalRoundsInWindow.set(5);
+    mockTotalRounds.set(5);
+    mockTotalCoursesPlayed.set(2);
+    fixture.detectChanges();
+
+    const textContent = fixture.nativeElement.textContent;
+    expect(textContent).toContain('12.4');
+    expect(textContent).toContain('(provisional)');
+    expect(fixture.nativeElement.querySelector('.grid').textContent).toContain('5');
+    expect(fixture.nativeElement.querySelector('.grid').textContent).toContain('2');
+  });
+
+  it('should display index without provisional and appropriate trend color when >= 20 rounds', () => {
+    mockHandicapIndex.set(10.1);
+    mockTotalRoundsInWindow.set(20);
+    mockTotalRounds.set(24);
+    mockTrend.set('improving');
+    fixture.detectChanges();
+
+    const textContent = fixture.nativeElement.textContent;
+    expect(textContent).toContain('10.1');
+    expect(textContent).not.toContain('(provisional)');
+
+    const trendEl = fixture.nativeElement.querySelector('.text-success-light');
+    expect(trendEl).toBeTruthy();
+    expect(trendEl.textContent).toContain('Improving');
+  });
+
+  it('should correctly render worsening and stable trends', () => {
+    mockTrend.set('worsening');
+    fixture.detectChanges();
+    let trendEl = fixture.nativeElement.querySelector('.text-error-light');
+    expect(trendEl).toBeTruthy();
+    expect(trendEl.textContent).toContain('Worsening');
+
+    mockTrend.set('stable');
+    fixture.detectChanges();
+    trendEl = fixture.nativeElement.querySelector('.text-frosted-blue');
+    expect(trendEl).toBeTruthy();
+    expect(trendEl.textContent).toContain('Stable');
+  });
+
+  it('should render the correct number of placeholder rows as rounds are added', () => {
+    const mockRound: RecentRoundDisplay = {
+      id: 'r1',
+      teeId: 't1',
+      date: '2026-04-18',
+      grossScore: 80,
+      differential: 10,
+      courseName: 'Test Course',
+    };
+
+    mockRecentRounds.set([]);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelectorAll('div[aria-hidden="true"]').length).toBe(3);
+
+    mockRecentRounds.set([mockRound]);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelectorAll('div[aria-hidden="true"]').length).toBe(2);
+
+    mockRecentRounds.set([mockRound, { ...mockRound, id: 'r2' }]);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelectorAll('div[aria-hidden="true"]').length).toBe(1);
+
+    mockRecentRounds.set([mockRound, { ...mockRound, id: 'r2' }, { ...mockRound, id: 'r3' }]);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelectorAll('div[aria-hidden="true"]').length).toBe(0);
+  });
+
+  it('should mark counting rounds with a green dot by ID, correctly handling duplicate differentials', () => {
+    mockRecentRounds.set([
+      { id: 'r1', teeId: 't1', date: '2026-04-01', grossScore: 80, differential: 10.5, courseName: 'Course A' },
+      { id: 'r2', teeId: 't1', date: '2026-03-30', grossScore: 80, differential: 10.5, courseName: 'Course B' },
+    ]);
+    mockUsedRoundIds.set(['r1']);
+    fixture.detectChanges();
+
+    const dots = fixture.nativeElement.querySelectorAll('.rounded-full');
+    expect(dots[0].classList.contains('bg-success')).toBe(true);
+    expect(dots[1].classList.contains('bg-success')).toBe(false);
+    expect(dots[1].classList.contains('bg-transparent')).toBe(true);
+  });
+});

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -1,13 +1,66 @@
-import { Component } from '@angular/core';
+import { Component, computed, inject, Signal, OnInit } from '@angular/core';
+import { DatePipe, DecimalPipe } from '@angular/common';
+import { RouterLink } from '@angular/router';
+import { NgIcon } from '@ng-icons/core';
+import { HandicapStateService, RecentRoundDisplay, RECENT_DISPLAY_COUNT } from '../../services/handicap-state.service';
+import { PageHeaderComponent } from '../../components/page-header/page-header.component';
 
 /**
- * Component representing the home page.
+ * Component representing the home page dashboard.
  */
 @Component({
   selector: 'app-home',
-  host: { class: 'block h-full' },
+  host: { class: 'flex flex-col h-full' },
   templateUrl: './home.component.html',
   standalone: true,
-  imports: [],
+  imports: [PageHeaderComponent, NgIcon, DatePipe, DecimalPipe, RouterLink],
 })
-export class HomePage {}
+export class HomePage implements OnInit {
+  private readonly handicapStateService = inject(HandicapStateService);
+
+  readonly handicapIndex = this.handicapStateService.handicapIndex;
+  readonly totalRoundsInWindow = this.handicapStateService.totalRoundsInWindow;
+  readonly totalRounds = this.handicapStateService.totalRounds;
+  readonly totalCoursesPlayed = this.handicapStateService.totalCoursesPlayed;
+  readonly trend = this.handicapStateService.trend;
+  readonly recentRounds: Signal<RecentRoundDisplay[]> = this.handicapStateService.recentRounds;
+  readonly usedRoundIds = this.handicapStateService.usedRoundIds;
+
+  readonly isProvisional = computed(() => this.totalRoundsInWindow() > 0 && this.totalRoundsInWindow() < 20);
+
+  readonly placeholders = computed(() => {
+    const count = RECENT_DISPLAY_COUNT - this.recentRounds().length;
+    return count > 0 ? new Array(count).fill(0) : [];
+  });
+
+  readonly trendDisplay = computed(() => {
+    const t = this.trend();
+    switch (t) {
+      case 'improving':
+        return { icon: 'ionCaretUp', text: 'Improving', class: 'text-success-light' };
+      case 'worsening':
+        return { icon: 'ionCaretDown', text: 'Worsening', class: 'text-error-light' };
+      case 'stable':
+        return { icon: 'ionCaretForward', text: 'Stable', class: 'text-frosted-blue' };
+      default:
+        return { icon: null, text: '', class: 'text-primary-font' };
+    }
+  });
+
+  /**
+   * Initializes the component and refreshes the handicap state.
+   */
+  async ngOnInit(): Promise<void> {
+    await this.handicapStateService.refresh();
+  }
+
+  /**
+   * Determines if a round is currently used in the handicap calculation.
+   *
+   * @param roundId - The ID of the round to check.
+   * @returns True if the round is used, false otherwise.
+   */
+  isRoundCounting(roundId: string): boolean {
+    return this.usedRoundIds().includes(roundId);
+  }
+}

--- a/src/app/pages/rounds/rounds.component.html
+++ b/src/app/pages/rounds/rounds.component.html
@@ -1,15 +1,15 @@
 <div class="flex flex-col h-full">
-  <header class="flex items-center justify-between px-4 py-3 pt-10 border-b border-borders shrink-0">
-    <h1 class="text-2xl font-medium m-0">Rounds</h1>
+  <app-page-header title="Rounds">
     <button
+      action
       [routerLink]="['/rounds/add']"
       type="button"
-      class="flex items-center justify-center gap-1 px-4 py-2 rounded-lg bg-primary text-true-obsidian text-lg font-medium border-none outline-none h-11 active:scale-[0.98] transition-transform"
+      class="flex items-center justify-center gap-1 px-4 py-2 rounded-lg bg-primary text-onyx text-lg font-medium border-none outline-none h-11 active:scale-[0.98] transition-transform"
     >
       <ng-icon name="ionAdd"></ng-icon>
       Add
     </button>
-  </header>
+  </app-page-header>
 
   <main class="flex-1 overflow-y-auto">
     <div class="px-4 py-6 h-full">

--- a/src/app/pages/rounds/rounds.component.ts
+++ b/src/app/pages/rounds/rounds.component.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { RouterLink } from '@angular/router';
+import { PageHeaderComponent } from '../../components/page-header/page-header.component';
 import { NgIcon } from '@ng-icons/core';
 
 /**
@@ -10,6 +11,6 @@ import { NgIcon } from '@ng-icons/core';
   host: { class: 'block h-full' },
   templateUrl: './rounds.component.html',
   standalone: true,
-  imports: [NgIcon, RouterLink],
+  imports: [NgIcon, RouterLink, PageHeaderComponent],
 })
 export class RoundsPage {}

--- a/src/app/services/handicap-state.service.spec.ts
+++ b/src/app/services/handicap-state.service.spec.ts
@@ -30,14 +30,21 @@ describe('HandicapStateService', () => {
 
     await service.refresh();
 
-    expect(service.snapshot()).toEqual({
-      handicapIndex: null,
-      totalRoundsCounted: 2,
-      usedDifferentials: [],
-    });
+    expect(service.handicapIndex()).toBeNull();
+    expect(service.totalRoundsInWindow()).toBe(2);
+    expect(service.usedRoundIds()).toEqual([]);
+    expect(service.usedDifferentials()).toEqual([]);
+    expect(service.totalRounds()).toBe(2);
+    expect(service.totalCoursesPlayed()).toBe(0);
+    expect(service.trend()).toBe('none');
+    expect(service.recentRounds()).toEqual([
+      { id: 'r2', teeId: 't1', date: '2026-03-02', grossScore: 88, differential: 16.2, courseName: 'Unknown Course' },
+      { id: 'r1', teeId: 't1', date: '2026-03-01', grossScore: 90, differential: 18.4, courseName: 'Unknown Course' },
+    ]);
   });
 
   it('computes handicap index and used differentials from the most recent rounds', async () => {
+    await db.tees.add({ id: 't1', courseId: 'c1', name: 'White', rating: 70, slope: 113, par: 72 });
     await db.rounds.bulkAdd([
       { id: 'r1', teeId: 't1', date: '2026-03-01', grossScore: 90, differential: 18.4 },
       { id: 'r2', teeId: 't1', date: '2026-03-02', grossScore: 88, differential: 16.2 },
@@ -49,8 +56,12 @@ describe('HandicapStateService', () => {
     await service.refresh();
 
     expect(service.handicapIndex()).toBe(10.9);
-    expect(service.totalRoundsCounted()).toBe(5);
+    expect(service.totalRoundsInWindow()).toBe(5);
+    expect(service.usedRoundIds()).toEqual(['r5']);
     expect(service.usedDifferentials()).toEqual([10.9]);
+    expect(service.totalRounds()).toBe(5);
+    expect(service.totalCoursesPlayed()).toBe(1);
+    expect(service.trend()).toBe('worsening');
   });
 
   it('refresh recomputes after new rounds are persisted', async () => {
@@ -62,13 +73,16 @@ describe('HandicapStateService', () => {
 
     await service.refresh();
     expect(service.handicapIndex()).toBe(11.5);
+    expect(service.trend()).toBe('none');
 
     await db.rounds.add({ id: 'r4', teeId: 't1', date: '2026-03-04', grossScore: 80, differential: 9.4 });
 
     await service.refresh();
 
     expect(service.handicapIndex()).toBe(8.4);
+    expect(service.usedRoundIds()).toEqual(['r4']);
     expect(service.usedDifferentials()).toEqual([9.4]);
+    expect(service.trend()).toBe('improving');
   });
 
   it('exposes the current WHS counting slice when more than 20 rounds exist', async () => {
@@ -86,8 +100,44 @@ describe('HandicapStateService', () => {
     await db.rounds.bulkAdd(rounds);
     await service.refresh();
 
-    expect(service.totalRoundsCounted()).toBe(20);
+    expect(service.totalRoundsInWindow()).toBe(20);
+    expect(service.usedRoundIds()).toEqual(['r21', 'r20', 'r19', 'r18', 'r17', 'r16', 'r15', 'r14']);
     expect(service.usedDifferentials()).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
     expect(service.handicapIndex()).toBe(4.5);
+    expect(service.trend()).toBe('improving');
+  });
+
+  it('correctly calculates worsening and none trends', async () => {
+    await db.rounds.bulkAdd([
+      { id: 'r1', teeId: 't1', date: '2026-03-01', grossScore: 80, differential: 10 },
+      { id: 'r2', teeId: 't1', date: '2026-03-02', grossScore: 80, differential: 10 },
+      { id: 'r3', teeId: 't1', date: '2026-03-03', grossScore: 80, differential: 10 },
+    ]);
+    await service.refresh();
+    expect(service.trend()).toBe('none');
+
+    await db.rounds.add({ id: 'r4', teeId: 't1', date: '2026-03-04', grossScore: 90, differential: 20 });
+    await service.refresh();
+    expect(service.trend()).toBe('worsening');
+  });
+
+  it('correctly identifies stable trend for small deltas', async () => {
+    // 20 rounds of 10. Index = 10
+    const rounds = Array.from({ length: 20 }, (_, i) => ({
+      id: `r${i + 1}`,
+      teeId: 't1',
+      date: `2026-03-${(i + 1).toString().padStart(2, '0')}`,
+      grossScore: 82,
+      differential: 10,
+    }));
+    await db.rounds.bulkAdd(rounds);
+    await service.refresh();
+    expect(service.handicapIndex()).toBe(10);
+
+    // Add 21st round: 9.2. New lowest 8: seven 10.0s, one 9.2. Avg = 9.9. Delta = -0.1 (stable)
+    await db.rounds.add({ id: 'r21', teeId: 't1', date: '2026-04-01', grossScore: 81, differential: 9.2 });
+    await service.refresh();
+    expect(service.handicapIndex()).toBe(9.9);
+    expect(service.trend()).toBe('stable');
   });
 });

--- a/src/app/services/handicap-state.service.ts
+++ b/src/app/services/handicap-state.service.ts
@@ -1,11 +1,22 @@
 import { Injectable, computed, inject, signal } from '@angular/core';
-import { db } from '../database/db';
+import { db, Round } from '../database/db';
 import { WhsService } from './whs.service';
+
+export interface RecentRoundDisplay extends Round {
+  courseName: string;
+}
+
+export const RECENT_DISPLAY_COUNT = 3;
 
 export interface HandicapStateSnapshot {
   handicapIndex: number | null;
-  totalRoundsCounted: number;
+  totalRoundsInWindow: number;
+  usedRoundIds: string[];
   usedDifferentials: number[];
+  totalRounds: number;
+  totalCoursesPlayed: number;
+  trend: 'improving' | 'worsening' | 'stable' | 'none';
+  recentRounds: RecentRoundDisplay[];
 }
 
 /**
@@ -18,27 +29,71 @@ export class HandicapStateService {
   private readonly whsService = inject(WhsService);
   private readonly snapshotState = signal<HandicapStateSnapshot>({
     handicapIndex: null,
-    totalRoundsCounted: 0,
+    totalRoundsInWindow: 0,
+    usedRoundIds: [],
     usedDifferentials: [],
+    totalRounds: 0,
+    totalCoursesPlayed: 0,
+    trend: 'none',
+    recentRounds: [],
   });
 
-  readonly snapshot = computed(() => this.snapshotState());
   readonly handicapIndex = computed(() => this.snapshotState().handicapIndex);
-  readonly totalRoundsCounted = computed(() => this.snapshotState().totalRoundsCounted);
+  readonly totalRoundsInWindow = computed(() => this.snapshotState().totalRoundsInWindow);
+  readonly usedRoundIds = computed(() => this.snapshotState().usedRoundIds);
   readonly usedDifferentials = computed(() => this.snapshotState().usedDifferentials);
+  readonly totalRounds = computed(() => this.snapshotState().totalRounds);
+  readonly totalCoursesPlayed = computed(() => this.snapshotState().totalCoursesPlayed);
+  readonly trend = computed(() => this.snapshotState().trend);
+  readonly recentRounds = computed(() => this.snapshotState().recentRounds);
 
   /**
    * Reloads persisted rounds and recomputes the current handicap snapshot.
    */
   async refresh(): Promise<void> {
-    const recentRounds = await db.rounds.orderBy('date').reverse().limit(20).toArray();
+    const recent21Rounds = await db.rounds.orderBy('date').reverse().limit(21).toArray();
+    const recentRounds = recent21Rounds.slice(0, 20);
     const recentDifferentials = recentRounds.map((round) => round.differential);
-    const usedDifferentials = this.whsService.getCountingDifferentials(recentDifferentials);
+    const usedRounds = this.whsService.getCountingRounds(recentRounds);
+    const usedRoundIds = usedRounds.map((r) => r.id);
+    const usedDifferentials = usedRounds.map((r) => r.differential);
+
+    const currentIndex = this.whsService.calculateHandicapIndex(recentDifferentials);
+
+    let trend: 'improving' | 'worsening' | 'stable' | 'none' = 'none';
+    if (recent21Rounds.length > 1) {
+      const previousDifferentials = recent21Rounds.slice(1, 21).map((r) => r.differential);
+      const previousIndex = this.whsService.calculateHandicapIndex(previousDifferentials);
+
+      if (currentIndex !== null && previousIndex !== null) {
+        trend = this.whsService.determineTrend(currentIndex, previousIndex);
+      }
+    }
+
+    const totalRounds = await db.rounds.count();
+
+    const uniqueTeeIds = (await db.rounds.orderBy('teeId').uniqueKeys()) as string[];
+    const tees = await db.tees.bulkGet(uniqueTeeIds);
+    const uniqueCourseIds = new Set(tees.map((tee) => tee?.courseId).filter((id) => id !== undefined));
+    const totalCoursesPlayed = uniqueCourseIds.size;
+
+    const recentDisplayRounds = await Promise.all(
+      recent21Rounds.slice(0, RECENT_DISPLAY_COUNT).map(async (r) => {
+        const tee = await db.tees.get(r.teeId);
+        const course = tee ? await db.courses.get(tee.courseId) : undefined;
+        return { ...r, courseName: course?.name || 'Unknown Course' };
+      }),
+    );
 
     this.snapshotState.set({
-      handicapIndex: this.whsService.calculateHandicapIndex(recentDifferentials),
-      totalRoundsCounted: recentRounds.length,
+      handicapIndex: currentIndex,
+      totalRoundsInWindow: recentRounds.length,
+      usedRoundIds,
       usedDifferentials,
+      totalRounds,
+      totalCoursesPlayed,
+      trend,
+      recentRounds: recentDisplayRounds,
     });
   }
 }

--- a/src/app/services/whs.service.spec.ts
+++ b/src/app/services/whs.service.spec.ts
@@ -9,11 +9,8 @@ describe('WhsService', () => {
 
   describe('calculateDifferential', () => {
     it('should calculate the WHS differential rounded to one decimal place', () => {
-      // (85 - 72.1) * (113 / 131) = 11.129 -> 11.1
       expect(service.calculateDifferential(85, 72.1, 131)).toBe(11.1);
-      // (72 - 72) * (113 / 113) = 0
       expect(service.calculateDifferential(72, 72, 113)).toBe(0);
-      // (100 - 68.5) * (113 / 120) = 29.6625 -> 29.7
       expect(service.calculateDifferential(100, 68.5, 120)).toBe(29.7);
     });
   });
@@ -26,21 +23,16 @@ describe('WhsService', () => {
     });
 
     it('should apply provisional calculation adjustments for 3 to 19 rounds', () => {
-      // 3 rounds: lowest 1 (12), adjustment -2 = 10
       expect(service.calculateHandicapIndex([15, 12, 20])).toBe(10);
-      // 5 rounds: lowest 1 (12), adjustment 0 = 12
       expect(service.calculateHandicapIndex([15, 12, 20, 18, 14])).toBe(12);
     });
 
     it('should calculate the index using the lowest 8 of the most recent 20 rounds', () => {
-      // 20 rounds: 1 to 20. Lowest 8 are 1..8. Sum = 36, Avg = 4.5
       const rounds = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20];
       expect(service.calculateHandicapIndex(rounds)).toBe(4.5);
     });
 
     it('should ignore rounds beyond the most recent 20', () => {
-      // 20 recent rounds of 10, 5 older rounds of 0.1
-      // If it used older rounds, the average would drop
       const recentRounds = new Array(20).fill(10);
       const olderRounds = new Array(5).fill(0.1);
       expect(service.calculateHandicapIndex([...recentRounds, ...olderRounds])).toBe(10);
@@ -48,8 +40,41 @@ describe('WhsService', () => {
 
     it('should apply the Golf Australia 0.93 multiplier when the flag is true', () => {
       const rounds = new Array(20).fill(10);
-      // Base index 10 * 0.93 = 9.3
       expect(service.calculateHandicapIndex(rounds, true)).toBe(9.3);
+    });
+  });
+
+  describe('getCountingRounds', () => {
+    it('should return an empty array if there are fewer than 3 rounds', () => {
+      expect(service.getCountingRounds([{ differential: 1 }, { differential: 2 }])).toEqual([]);
+    });
+
+    it('should return the correct subset of lowest rounds based on round count', () => {
+      const rounds = [
+        { id: '1', differential: 15 },
+        { id: '2', differential: 12 },
+        { id: '3', differential: 20 },
+        { id: '4', differential: 18 },
+        { id: '5', differential: 14 },
+      ];
+      expect(service.getCountingRounds(rounds)).toEqual([{ id: '2', differential: 12 }]);
+    });
+
+    it('should handle duplicate differentials correctly', () => {
+      const rounds = [
+        { id: '1', differential: 10 },
+        { id: '2', differential: 10 },
+        { id: '3', differential: 15 },
+        { id: '4', differential: 20 },
+        { id: '5', differential: 5 },
+      ];
+      expect(service.getCountingRounds(rounds)).toEqual([{ id: '5', differential: 5 }]);
+
+      const sixRounds = [...rounds, { id: '6', differential: 25 }];
+      const result = service.getCountingRounds(sixRounds);
+      expect(result.length).toBe(2);
+      expect(result).toContain(sixRounds[4]);
+      expect(result.some((r) => r.differential === 10)).toBe(true);
     });
   });
 
@@ -59,10 +84,8 @@ describe('WhsService', () => {
     });
 
     it('should return the correct subset of lowest differentials based on round count', () => {
-      // 5 rounds: lowest 1
       expect(service.getCountingDifferentials([15, 12, 20, 18, 14])).toEqual([12]);
 
-      // 20+ rounds: lowest 8 from the most recent 20
       const recentRounds = [...new Array(8).fill(5), ...new Array(12).fill(20)];
       expect(service.getCountingDifferentials(recentRounds)).toEqual(new Array(8).fill(5));
     });

--- a/src/app/services/whs.service.ts
+++ b/src/app/services/whs.service.ts
@@ -82,7 +82,31 @@ export class WhsService {
   }
 
   /**
+   * Returns the subset of rounds currently counted toward the handicap index.
+   *
+   * @param rounds - An array of historical rounds (must include 'differential' property).
+   * @returns The subset of rounds currently used in the handicap calculation.
+   */
+  getCountingRounds<T extends { differential: number }>(rounds: T[]): T[] {
+    if (!rounds || rounds.length < 3) {
+      return [];
+    }
+
+    const { lowestN } = this.getSelectionRule(rounds.length);
+
+    // Sort by differential ascending, then by original index as a deterministic
+    // tie-breaker so equal differentials always produce the same selection.
+    return rounds
+      .map((r, i) => ({ r, i }))
+      .sort((a, b) => a.r.differential - b.r.differential || a.i - b.i)
+      .slice(0, lowestN)
+      .map(({ r }) => r);
+  }
+
+  /**
    * Returns the subset of differentials currently counted toward the handicap index.
+   * Enforces the WHS "most recent 20" window internally regardless of how many
+   * differentials are supplied by the caller.
    *
    * @param differentials - An array of historical differentials ordered from most recent to oldest.
    * @returns The sorted differentials currently used in the handicap calculation.
@@ -93,9 +117,8 @@ export class WhsService {
     }
 
     const recentDifferentials = differentials.slice(0, 20);
-    const { lowestN } = this.getSelectionRule(recentDifferentials.length);
-
-    return [...recentDifferentials].sort((a, b) => a - b).slice(0, lowestN);
+    const rounds = recentDifferentials.map((d) => ({ differential: d }));
+    return this.getCountingRounds(rounds).map((r) => r.differential);
   }
 
   /**

--- a/src/styles.css
+++ b/src/styles.css
@@ -2,25 +2,30 @@
 @import 'tailwindcss';
 
 @theme {
-  --color-championship-gold: oklch(0.8606 0.1731 91.94);
-  --color-championship-gold-tint: oklch(0.9284 0.099751 92.1447);
-  --color-true-obsidian: oklch(0.1785 0.0041 285.98);
-  --color-onyx: oklch(0.2103 0.0059 285.89);
-  --color-graphite: oklch(0.3116 0.0106 285.77);
-  --color-warm-white: oklch(0.9587 0.0027 286.35);
-  --color-warm-white-dim: oklch(0.9197 0.004 286.32);
-  --color-ruby: oklch(0.4496 0.1811 28.83);
-  --color-ruby-tint: oklch(0.6791 0.1947 23.88);
+  --color-bright-amber: #facc15;
+  --color-jasmine: #fce279;
+  --color-onyx: #111113;
+  --color-carbon-black: #18181b;
+  --color-graphite: #303036;
+  --color-platinum: #f2f2f3;
+  --color-alabaster-grey: #e4e4e7;
+  --color-brick-ember: #ca0c02;
+  --color-vibrant-coral: #fd6f68;
+  --color-bright-fern: #389457;
+  --color-mint-glow: #84d39c;
+  --color-frosted-blue: #9ce7fc;
 
-  --color-primary: var(--color-championship-gold);
-  --color-primary-light: var(--color-championship-gold-tint);
-  --color-background: var(--color-true-obsidian);
-  --color-surface: var(--color-onyx);
+  --color-primary: var(--color-bright-amber);
+  --color-primary-light: var(--color-jasmine);
+  --color-background: var(--color-onyx);
+  --color-surface: var(--color-carbon-black);
   --color-borders: var(--color-graphite);
-  --color-primary-font: var(--color-warm-white);
-  --color-secondary-font: var(--color-warm-white-dim);
-  --color-error: var(--color-ruby);
-  --color-error-light: var(--color-ruby-tint);
+  --color-primary-font: var(--color-platinum);
+  --color-secondary-font: var(--color-alabaster-grey);
+  --color-error: var(--color-brick-ember);
+  --color-error-light: var(--color-vibrant-coral);
+  --color-success: var(--color-bright-fern);
+  --color-success-light: var(--color-mint-glow);
 
   --font-sans: 'IBM Plex Sans Variable', sans-serif;
   --font-weight-light: 400;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  optimizeDeps: {
+    include: ['dexie', 'fake-indexeddb', 'fake-indexeddb/auto'],
+  },
+  test: {
+    pool: 'forks',
+  },
+});


### PR DESCRIPTION
This branch adds a full home dashboard for handicap tracking and refactors the app around a richer persisted handicap snapshot.

## What Changed

- Reworked the home page into a dashboard that shows the current Handicap Index, provisional status, trend, round count, course count, and recent rounds.
- Expanded `HandicapStateService` to compute and expose a richer snapshot, including counting rounds, used differentials, total rounds, distinct courses played, recent display rounds, and trend direction.
- Tightened `WhsService` with explicit counting-round helpers and trend classification logic.
- Added a reusable `PageHeaderComponent` and updated pages to use the shared header pattern.
- Updated icon registration and global styling to support the new dashboard layout and visual treatment.
- Added and updated tests for the WHS calculations, handicap snapshot state, and home dashboard behavior.

## Notes

- The dashboard logic now derives trend from the current index versus the previous index, so the home screen can show improving, worsening, or stable movement.
- Recent rounds are displayed with course names resolved from the stored tee and course data, falling back to `Unknown Course` when the relationship is missing.

## Testing

- New unit coverage was added for `WhsService` and `HandicapStateService`.
- A home page spec was added to cover the dashboard rendering and state-driven UI.