### PR TITLE
fix: minor UI polish round card divider style and home screen card sizing

### DIFF
--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -51,12 +51,16 @@
     </div>
 
     <div class="grid grid-cols-2 gap-3 min-[380px]:gap-4 shrink-0 py-4">
-      <div class="bg-surface rounded-2xl p-3 min-[380px]:p-4 flex flex-col items-center justify-center shadow-sm">
-        <span class="text-xl min-[380px]:text-2xl font-bold text-primary-font">{{ totalRounds() }}</span>
+      <div
+        class="bg-surface rounded-2xl px-3 py-2.5 min-[380px]:px-4 min-[380px]:py-3 flex flex-col items-center justify-center shadow-sm"
+      >
+        <span class="text-lg min-[380px]:text-xl font-medium text-primary-font">{{ totalRounds() }}</span>
         <span class="text-secondary-font text-xs min-[380px]:text-sm mt-1">Rounds</span>
       </div>
-      <div class="bg-surface rounded-2xl p-3 min-[380px]:p-4 flex flex-col items-center justify-center shadow-sm">
-        <span class="text-xl min-[380px]:text-2xl font-bold text-primary-font">{{ totalCoursesPlayed() }}</span>
+      <div
+        class="bg-surface rounded-2xl px-3 py-2.5 min-[380px]:px-4 min-[380px]:py-3 flex flex-col items-center justify-center shadow-sm"
+      >
+        <span class="text-lg min-[380px]:text-xl font-medium text-primary-font">{{ totalCoursesPlayed() }}</span>
         <span class="text-secondary-font text-xs min-[380px]:text-sm mt-1">Courses</span>
       </div>
     </div>

--- a/src/app/pages/rounds/rounds.component.html
+++ b/src/app/pages/rounds/rounds.component.html
@@ -69,7 +69,8 @@
               </div>
               <div
                 class="w-px self-stretch"
-                [class.bg-borders]="!legacy"
+                [class.bg-dark-spruce]="counting"
+                [class.bg-borders]="!counting && !legacy"
                 [class.bg-secondary-font]="legacy"
                 [class.opacity-10]="legacy"
               ></div>


### PR DESCRIPTION
This pull request makes small but important UI adjustments to improve the visual consistency and clarity of summary statistics and divider elements on the home and rounds pages.

UI improvements to summary statistics:

* Updated the styling of the "Rounds" and "Courses" summary cards in `home.component.html` to use slightly smaller font sizes, medium font weight instead of bold, and adjusted padding for better visual balance.

Visual clarity for divider elements:

* Modified the divider in `rounds.component.html` to display a different background color (`bg-dark-spruce`) when the `counting` variable is true, and to use the default border color only when neither `counting` nor `legacy` are true.