### PR TITLE
fix: remove double rounding from differential calculation

### DIFF
--- a/src/app/services/whs.service.spec.ts
+++ b/src/app/services/whs.service.spec.ts
@@ -13,6 +13,10 @@ describe('WhsService', () => {
       expect(service.calculateDifferential(72, 72, 113)).toBe(0);
       expect(service.calculateDifferential(100, 68.5, 120)).toBe(29.7);
     });
+
+    it('should not pre-round boundary values before rounding to one decimal place', () => {
+      expect(service.calculateDifferential(60, 50, 55)).toBe(20.5);
+    });
   });
 
   describe('calculateHandicapIndex', () => {

--- a/src/app/services/whs.service.spec.ts
+++ b/src/app/services/whs.service.spec.ts
@@ -31,6 +31,10 @@ describe('WhsService', () => {
       expect(service.calculateHandicapIndex([15, 12, 20, 18, 14])).toBe(12);
     });
 
+    it('should round provisional index boundary values with the precision guard', () => {
+      expect(service.calculateHandicapIndex([5.2, 16.9, 17, 18, 19, 20])).toBe(10.1);
+    });
+
     it('should calculate the index using the lowest 8 of the most recent 20 rounds', () => {
       const rounds = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20];
       expect(service.calculateHandicapIndex(rounds)).toBe(4.5);

--- a/src/app/services/whs.service.ts
+++ b/src/app/services/whs.service.ts
@@ -46,9 +46,7 @@ export class WhsService {
    */
   calculateDifferential(score: number, rating: number, slope: number): number {
     const rawDifferential = (score - rating) * (WHS_LIMITS.STANDARD_SLOPE / slope);
-    // Round to 2dp first to eliminate floating-point noise, then to 1dp
-    const roundedTo2dp = Math.round(rawDifferential * 100) / 100;
-    return Math.round(roundedTo2dp * 10) / 10;
+    return this.roundToNearestTenth(rawDifferential);
   }
 
   /**
@@ -78,7 +76,7 @@ export class WhsService {
 
     const index = average + adjustment;
 
-    return Math.round(index * 10) / 10;
+    return this.roundToNearestTenth(index);
   }
 
   /**
@@ -150,5 +148,9 @@ export class WhsService {
     }
 
     return this.PROVISIONAL_TABLE[numRounds];
+  }
+
+  private roundToNearestTenth(value: number): number {
+    return Math.round(Number((value * 10).toPrecision(15))) / 10;
   }
 }


### PR DESCRIPTION
This pull request refactors the rounding logic in the `WhsService` to ensure consistent and accurate rounding to one decimal place, and adds a test to verify correct handling of boundary values. The most important changes are:

Rounding logic improvements:
* Introduced a new private method `roundToNearestTenth` in `WhsService` to handle rounding to one decimal place more accurately, avoiding pre-rounding to two decimal places and reducing floating-point errors. This method is now used in both `calculateDifferential` and `calculateHandicapIndex`. [[1]](diffhunk://#diff-8bb62ccbaf6af23c43fcb8a70c5a78419a92460600f89cdf57cee4fffffc1f6fL49-R49) [[2]](diffhunk://#diff-8bb62ccbaf6af23c43fcb8a70c5a78419a92460600f89cdf57cee4fffffc1f6fL81-R79) [[3]](diffhunk://#diff-8bb62ccbaf6af23c43fcb8a70c5a78419a92460600f89cdf57cee4fffffc1f6fR152-R155)

Testing:
* Added a unit test to confirm that boundary values are not pre-rounded before rounding to one decimal place in `calculateDifferential`, ensuring correct calculation results for edge cases.