### PR TITLE
fix: round dates display one day earlier on devices east of utc eg bst

### DIFF
--- a/src/app/pages/add-round/add-round.component.ts
+++ b/src/app/pages/add-round/add-round.component.ts
@@ -15,6 +15,7 @@ import { PopUpComponent } from '../../components/pop-up/pop-up.component';
 import { PageHeaderComponent } from '../../components/page-header/page-header.component';
 import { RoundFormFieldsComponent } from '../../components/round-form-fields/round-form-fields.component';
 import { RoundFormPageBase } from '../shared/round-form-page.base';
+import { FormatDatePipe } from '../../pipes/format-date.pipe';
 
 interface PendingRoundPayload {
   teeId: string;
@@ -245,11 +246,12 @@ export class AddRoundPage extends RoundFormPageBase implements OnInit {
   private buildDuplicateSummary(): string {
     const selectedCourse = this.courses.find((course) => course.id === this.selectedCourseId);
     const selectedTee = this.tees.find((tee) => tee.id === this.roundForm.controls.teeId.getRawValue());
+    const formattedDate = FormatDatePipe.format(this.roundForm.controls.date.getRawValue(), 'long');
 
     if (!selectedCourse || !selectedTee) {
-      return `A round already exists for ${this.formatDate(this.roundForm.controls.date.getRawValue())}.`;
+      return `A round already exists for ${formattedDate}.`;
     }
 
-    return `A round on ${selectedTee.name} tee at ${selectedCourse.name} already exists for ${this.formatDate(this.roundForm.controls.date.getRawValue())}.`;
+    return `A round on ${selectedTee.name} tee at ${selectedCourse.name} already exists for ${formattedDate}.`;
   }
 }

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -100,7 +100,7 @@
                   round.courseName
                 }}</span>
                 <span class="text-secondary-font text-xs min-[380px]:text-sm mt-0.5">{{
-                  round.date | date: 'd MMM' : 'UTC'
+                  round.date | formatDate: 'short'
                 }}</span>
               </div>
             </div>

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -1,9 +1,10 @@
 import { Component, computed, inject, Signal, OnInit } from '@angular/core';
-import { DatePipe, DecimalPipe } from '@angular/common';
+import { DecimalPipe } from '@angular/common';
 import { RouterLink } from '@angular/router';
 import { NgIcon } from '@ng-icons/core';
 import { HandicapStateService, RecentRoundDisplay, RECENT_DISPLAY_COUNT } from '../../services/handicap-state.service';
 import { PageHeaderComponent } from '../../components/page-header/page-header.component';
+import { FormatDatePipe } from '../../pipes/format-date.pipe';
 
 /**
  * Component representing the home page dashboard.
@@ -13,7 +14,7 @@ import { PageHeaderComponent } from '../../components/page-header/page-header.co
   host: { class: 'flex flex-col h-full' },
   templateUrl: './home.component.html',
   standalone: true,
-  imports: [PageHeaderComponent, NgIcon, DatePipe, DecimalPipe, RouterLink],
+  imports: [PageHeaderComponent, NgIcon, FormatDatePipe, DecimalPipe, RouterLink],
 })
 export class HomePage implements OnInit {
   private readonly handicapStateService = inject(HandicapStateService);

--- a/src/app/pages/rounds/rounds.component.html
+++ b/src/app/pages/rounds/rounds.component.html
@@ -52,7 +52,7 @@
                 {{ row.courseName }}
               </h3>
               <p class="font-light text-secondary-font text-sm m-0 mt-0.5" [class.opacity-70]="legacy">
-                {{ row.teeName }} · {{ row.date | date: 'dd MMM yyyy' : 'UTC' }}
+                {{ row.teeName }} · {{ row.date | formatDate: 'long' }}
               </p>
             </div>
 

--- a/src/app/pages/rounds/rounds.component.ts
+++ b/src/app/pages/rounds/rounds.component.ts
@@ -1,8 +1,9 @@
 import { ChangeDetectionStrategy, Component, OnInit, computed, inject, signal } from '@angular/core';
-import { DatePipe, DecimalPipe } from '@angular/common';
+import { DecimalPipe } from '@angular/common';
 import { RouterLink } from '@angular/router';
 import { NgIcon } from '@ng-icons/core';
 import { PageHeaderComponent } from '../../components/page-header/page-header.component';
+import { FormatDatePipe } from '../../pipes/format-date.pipe';
 import {
   SegmentedControlComponent,
   SegmentedControlOption,
@@ -24,7 +25,7 @@ const LEGACY_INDEX_THRESHOLD = 20;
   templateUrl: './rounds.component.html',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [NgIcon, RouterLink, DatePipe, DecimalPipe, PageHeaderComponent, SegmentedControlComponent],
+  imports: [NgIcon, RouterLink, FormatDatePipe, DecimalPipe, PageHeaderComponent, SegmentedControlComponent],
 })
 export class RoundsPage implements OnInit {
   private readonly handicapState = inject(HandicapStateService);

--- a/src/app/pages/shared/round-form-page.base.ts
+++ b/src/app/pages/shared/round-form-page.base.ts
@@ -10,6 +10,7 @@ import {
 import { BottomSheetService } from '../../services/bottom-sheet.service';
 import { CourseService } from '../../services/course.service';
 import { ToastService } from '../../services/toast.service';
+import { FormatDatePipe } from '../../pipes/format-date.pipe';
 
 export interface RoundFormValue {
   courseId: string;
@@ -244,7 +245,7 @@ export abstract class RoundFormPageBase {
       return '';
     }
 
-    const formattedDate = this.formatDate(value);
+    const formattedDate = FormatDatePipe.format(value, 'long');
     return this.isToday(value) ? `${formattedDate} (Today)` : formattedDate;
   }
 
@@ -285,17 +286,6 @@ export abstract class RoundFormPageBase {
     } finally {
       this.cdr.markForCheck();
     }
-  }
-
-  protected formatDate(value: string): string {
-    const [year, month, day] = value.split('-').map(Number);
-    const date = new Date(year, month - 1, day);
-
-    return new Intl.DateTimeFormat('en-GB', {
-      day: '2-digit',
-      month: 'short',
-      year: 'numeric',
-    }).format(date);
   }
 
   protected sortByName<T extends { name: string }>(items: T[]): T[] {

--- a/src/app/pipes/format-date.pipe.spec.ts
+++ b/src/app/pipes/format-date.pipe.spec.ts
@@ -1,0 +1,22 @@
+import { FormatDatePipe } from './format-date.pipe';
+
+describe('FormatDatePipe', () => {
+  const pipe = new FormatDatePipe();
+
+  it('formats a YYYY-MM-DD string in short mode without UTC conversion', () => {
+    expect(pipe.transform('2026-05-03', 'short')).toBe('3 May');
+  });
+
+  it('formats a YYYY-MM-DD string in long mode without UTC conversion', () => {
+    expect(pipe.transform('2026-05-03', 'long')).toBe('3 May 2026');
+  });
+
+  it('uses long mode by default', () => {
+    expect(pipe.transform('2026-05-03')).toBe('3 May 2026');
+  });
+
+  it('returns an empty string when no date is provided', () => {
+    expect(pipe.transform(undefined)).toBe('');
+    expect(pipe.transform(null)).toBe('');
+  });
+});

--- a/src/app/pipes/format-date.pipe.spec.ts
+++ b/src/app/pipes/format-date.pipe.spec.ts
@@ -23,4 +23,11 @@ describe('FormatDatePipe', () => {
     expect(pipe.transform(undefined)).toBe('');
     expect(pipe.transform(null)).toBe('');
   });
+
+  it.each(['2026/05/03', '2026-05', '2026-May-03', '2026-02-31'])(
+    'returns the original value when %s cannot be parsed as a valid YYYY-MM-DD date',
+    (value) => {
+      expect(pipe.transform(value)).toBe(value);
+    },
+  );
 });

--- a/src/app/pipes/format-date.pipe.spec.ts
+++ b/src/app/pipes/format-date.pipe.spec.ts
@@ -1,5 +1,9 @@
 import { FormatDatePipe } from './format-date.pipe';
 
+// These tests verify format correctness only. The UTC off-by-one regression (dates
+// displaying one day earlier for UTC+ users) is structural: the fix avoids new Date(string)
+// in favour of new Date(year, month - 1, day) so the date is always local midnight.
+// That invariant can only be demonstrated end-to-end in a UTC+ environment (e.g. TZ=Europe/London).
 describe('FormatDatePipe', () => {
   const pipe = new FormatDatePipe();
 

--- a/src/app/pipes/format-date.pipe.ts
+++ b/src/app/pipes/format-date.pipe.ts
@@ -14,6 +14,8 @@ const FORMAT_OPTIONS: Record<FormatDateMode, Intl.DateTimeFormatOptions> = {
   },
 };
 
+const DATE_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
+
 /**
  * Formats persisted round date strings without shifting calendar days across timezones.
  */
@@ -22,6 +24,11 @@ const FORMAT_OPTIONS: Record<FormatDateMode, Intl.DateTimeFormatOptions> = {
   standalone: true,
 })
 export class FormatDatePipe implements PipeTransform {
+  private static readonly FORMATTERS: Record<FormatDateMode, Intl.DateTimeFormat> = {
+    short: new Intl.DateTimeFormat('en-GB', FORMAT_OPTIONS.short),
+    long: new Intl.DateTimeFormat('en-GB', FORMAT_OPTIONS.long),
+  };
+
   /**
    * Pipe wrapper for {@link FormatDatePipe.format}.
    *
@@ -38,16 +45,31 @@ export class FormatDatePipe implements PipeTransform {
    *
    * @param value - The date value in YYYY-MM-DD format.
    * @param mode - The display format to apply.
-   * @returns The formatted date, or an empty string when no value is provided.
+   * @returns The formatted date, an empty string when no value is provided, or the original value when parsing fails.
    */
   static format(value: string | null | undefined, mode: FormatDateMode = 'long'): string {
     if (!value) {
       return '';
     }
 
-    const [year, month, day] = value.split('-').map(Number);
-    const date = new Date(year, month - 1, day);
+    const match = DATE_PATTERN.exec(value);
+    if (!match) {
+      return value;
+    }
 
-    return new Intl.DateTimeFormat('en-GB', FORMAT_OPTIONS[mode]).format(date);
+    const [, yearValue, monthValue, dayValue] = match;
+    const year = Number(yearValue);
+    const month = Number(monthValue);
+    const day = Number(dayValue);
+    if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day)) {
+      return value;
+    }
+
+    const date = new Date(year, month - 1, day);
+    if (date.getFullYear() !== year || date.getMonth() !== month - 1 || date.getDate() !== day) {
+      return value;
+    }
+
+    return FormatDatePipe.FORMATTERS[mode].format(date);
   }
 }

--- a/src/app/pipes/format-date.pipe.ts
+++ b/src/app/pipes/format-date.pipe.ts
@@ -23,7 +23,7 @@ const FORMAT_OPTIONS: Record<FormatDateMode, Intl.DateTimeFormatOptions> = {
 })
 export class FormatDatePipe implements PipeTransform {
   /**
-   * Formats an ISO calendar date string using local calendar semantics.
+   * Pipe wrapper for {@link FormatDatePipe.format}.
    *
    * @param value - The date value in YYYY-MM-DD format.
    * @param mode - The display format to apply.

--- a/src/app/pipes/format-date.pipe.ts
+++ b/src/app/pipes/format-date.pipe.ts
@@ -1,0 +1,53 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+export type FormatDateMode = 'short' | 'long';
+
+const FORMAT_OPTIONS: Record<FormatDateMode, Intl.DateTimeFormatOptions> = {
+  short: {
+    day: 'numeric',
+    month: 'short',
+  },
+  long: {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  },
+};
+
+/**
+ * Formats persisted round date strings without shifting calendar days across timezones.
+ */
+@Pipe({
+  name: 'formatDate',
+  standalone: true,
+})
+export class FormatDatePipe implements PipeTransform {
+  /**
+   * Formats an ISO calendar date string using local calendar semantics.
+   *
+   * @param value - The date value in YYYY-MM-DD format.
+   * @param mode - The display format to apply.
+   * @returns The formatted date, or an empty string when no value is provided.
+   */
+  transform(value: string | null | undefined, mode: FormatDateMode = 'long'): string {
+    return FormatDatePipe.format(value, mode);
+  }
+
+  /**
+   * Formats an ISO calendar date string using local calendar semantics.
+   *
+   * @param value - The date value in YYYY-MM-DD format.
+   * @param mode - The display format to apply.
+   * @returns The formatted date, or an empty string when no value is provided.
+   */
+  static format(value: string | null | undefined, mode: FormatDateMode = 'long'): string {
+    if (!value) {
+      return '';
+    }
+
+    const [year, month, day] = value.split('-').map(Number);
+    const date = new Date(year, month - 1, day);
+
+    return new Intl.DateTimeFormat('en-GB', FORMAT_OPTIONS[mode]).format(date);
+  }
+}


### PR DESCRIPTION
This pull request introduces a new `FormatDatePipe` to standardize and fix date formatting across the application, replacing previous approaches that could cause timezone-related bugs. The pipe ensures consistent display of dates regardless of the user's timezone and provides both "short" and "long" formatting options. All relevant components and templates have been updated to use this new pipe, and the old custom date formatting logic has been removed.

**Date formatting improvements:**

* Added a new standalone `FormatDatePipe` (`src/app/pipes/format-date.pipe.ts`) that formats `YYYY-MM-DD` strings into human-readable dates without timezone shifts, supporting both "short" and "long" formats. This fixes prior issues where dates could display incorrectly for users in UTC+ timezones.
* Updated all usages of date formatting in templates (`home.component.html`, `rounds.component.html`) and component logic (`add-round.component.ts`, `round-form-page.base.ts`) to use `FormatDatePipe` instead of Angular's `DatePipe` or custom formatting functions. [[1]](diffhunk://#diff-d5e48473dc70f4e45b26da87c1e1d1d62f3047ae0f2da8a2e267fea4ea23ef08L103-R103) [[2]](diffhunk://#diff-f988b15d136ed6a510f304e5495ee6577c4413c4fcdfcd992d381804b279322cL55-R55) [[3]](diffhunk://#diff-364f0a6592ce2d8f6764d7790fc5f849780d2f4eb531c1e10bae4835433f2745R18) [[4]](diffhunk://#diff-364f0a6592ce2d8f6764d7790fc5f849780d2f4eb531c1e10bae4835433f2745R249-R255) [[5]](diffhunk://#diff-2f4983df73e8dba378c083a3e703b3122b6518c17e6e63529ee62560bacebf94R13) [[6]](diffhunk://#diff-2f4983df73e8dba378c083a3e703b3122b6518c17e6e63529ee62560bacebf94L247-R248) [[7]](diffhunk://#diff-2f4983df73e8dba378c083a3e703b3122b6518c17e6e63529ee62560bacebf94L290-L300) [[8]](diffhunk://#diff-b6925a73e781eaea7dc28accc00cd213a1cd22b15d83b251d04950e85e7fa4ddL2-R7) [[9]](diffhunk://#diff-b6925a73e781eaea7dc28accc00cd213a1cd22b15d83b251d04950e85e7fa4ddL16-R17) [[10]](diffhunk://#diff-14b75ed0c549dbfb85e11118d3647dcbf9b1dfb5f428e876d4ee5d1c09c4c789L2-R6) [[11]](diffhunk://#diff-14b75ed0c549dbfb85e11118d3647dcbf9b1dfb5f428e876d4ee5d1c09c4c789L27-R28)

**Code cleanup and consistency:**

* Removed the custom `formatDate` method from `RoundFormPageBase`, consolidating all formatting logic into the new pipe for maintainability.

**Testing:**

* Added a unit test suite for `FormatDatePipe` (`format-date.pipe.spec.ts`) to verify correct formatting and edge cases, ensuring reliability of the new implementation.