### PR TITLE
fix: browser autocomplete and input memory appear on form fields

### DIFF
--- a/src/app/components/add-course-modal/add-course-modal.component.html
+++ b/src/app/components/add-course-modal/add-course-modal.component.html
@@ -4,7 +4,7 @@
   </header>
 
   <div class="flex-1 px-4 py-6">
-    <form [formGroup]="courseForm" (ngSubmit)="onSubmit()" class="flex flex-col gap-6">
+    <form [formGroup]="courseForm" (ngSubmit)="onSubmit()" autocomplete="off" class="flex flex-col gap-6">
       <div>
         <label class="block text-xs font-light text-secondary-font mb-2" for="courseName">Course name</label>
         <input
@@ -13,7 +13,6 @@
           class="w-full bg-background border border-borders rounded-xl px-4 py-3 text-base text-primary-font focus:outline-none focus:border-primary-light box-border"
           [appValidationStatus]="addCourseSubmitCount"
           type="text"
-          autocomplete="off"
         />
       </div>
 
@@ -31,7 +30,6 @@
           class="w-full bg-background border border-borders rounded-xl px-4 py-3 text-base text-primary-font focus:outline-none focus:border-primary-light box-border"
           [appValidationStatus]="addCourseSubmitCount"
           type="text"
-          autocomplete="off"
         />
       </div>
 
@@ -46,7 +44,6 @@
             type="number"
             inputmode="decimal"
             step="0.1"
-            autocomplete="off"
           />
         </div>
 
@@ -59,7 +56,6 @@
             [appValidationStatus]="addCourseSubmitCount"
             type="number"
             inputmode="numeric"
-            autocomplete="off"
           />
         </div>
 
@@ -72,7 +68,6 @@
             [appValidationStatus]="addCourseSubmitCount"
             type="number"
             inputmode="numeric"
-            autocomplete="off"
           />
         </div>
       </div>

--- a/src/app/components/add-course-modal/add-course-modal.component.html
+++ b/src/app/components/add-course-modal/add-course-modal.component.html
@@ -13,6 +13,7 @@
           class="w-full bg-background border border-borders rounded-xl px-4 py-3 text-base text-primary-font focus:outline-none focus:border-primary-light box-border"
           [appValidationStatus]="addCourseSubmitCount"
           type="text"
+          autocomplete="off"
         />
       </div>
 
@@ -30,6 +31,7 @@
           class="w-full bg-background border border-borders rounded-xl px-4 py-3 text-base text-primary-font focus:outline-none focus:border-primary-light box-border"
           [appValidationStatus]="addCourseSubmitCount"
           type="text"
+          autocomplete="off"
         />
       </div>
 
@@ -44,6 +46,7 @@
             type="number"
             inputmode="decimal"
             step="0.1"
+            autocomplete="off"
           />
         </div>
 
@@ -56,6 +59,7 @@
             [appValidationStatus]="addCourseSubmitCount"
             type="number"
             inputmode="numeric"
+            autocomplete="off"
           />
         </div>
 
@@ -68,6 +72,7 @@
             [appValidationStatus]="addCourseSubmitCount"
             type="number"
             inputmode="numeric"
+            autocomplete="off"
           />
         </div>
       </div>

--- a/src/app/components/add-tee-modal/add-tee-modal.component.html
+++ b/src/app/components/add-tee-modal/add-tee-modal.component.html
@@ -4,7 +4,7 @@
   </header>
 
   <div class="flex-1 px-4 py-6">
-    <form [formGroup]="teeForm" (ngSubmit)="onSubmit()" class="flex flex-col gap-6">
+    <form [formGroup]="teeForm" (ngSubmit)="onSubmit()" autocomplete="off" class="flex flex-col gap-6">
       <app-tee-form [parentForm]="teeForm" [submitCount]="teeSubmitCount"></app-tee-form>
 
       <button

--- a/src/app/components/edit-course-modal/edit-course-modal.component.html
+++ b/src/app/components/edit-course-modal/edit-course-modal.component.html
@@ -4,7 +4,7 @@
   </header>
 
   <div class="flex-1 px-4 py-6">
-    <form [formGroup]="editCourseForm" (ngSubmit)="onSubmit()" class="flex flex-col gap-6">
+    <form [formGroup]="editCourseForm" (ngSubmit)="onSubmit()" autocomplete="off" class="flex flex-col gap-6">
       <div>
         <label class="block text-xs font-light text-secondary-font mb-2" for="editCourseName">Course name</label>
         <input
@@ -12,7 +12,6 @@
           formControlName="courseName"
           class="w-full bg-background border border-borders rounded-xl px-4 py-3 text-base text-primary-font focus:outline-none focus:border-primary-light box-border"
           type="text"
-          autocomplete="off"
         />
       </div>
 

--- a/src/app/components/edit-course-modal/edit-course-modal.component.html
+++ b/src/app/components/edit-course-modal/edit-course-modal.component.html
@@ -12,6 +12,7 @@
           formControlName="courseName"
           class="w-full bg-background border border-borders rounded-xl px-4 py-3 text-base text-primary-font focus:outline-none focus:border-primary-light box-border"
           type="text"
+          autocomplete="off"
         />
       </div>
 

--- a/src/app/components/edit-tee-modal/edit-tee-modal.component.html
+++ b/src/app/components/edit-tee-modal/edit-tee-modal.component.html
@@ -4,7 +4,7 @@
   </header>
 
   <div class="flex-1 px-4 py-6">
-    <form [formGroup]="editTeeForm" (ngSubmit)="onSubmit()" class="flex flex-col gap-6">
+    <form [formGroup]="editTeeForm" (ngSubmit)="onSubmit()" autocomplete="off" class="flex flex-col gap-6">
       <app-tee-form [parentForm]="editTeeForm" [submitCount]="editTeeSubmitCount" idPrefix="edit"></app-tee-form>
 
       <div class="flex flex-col gap-3 pt-2">

--- a/src/app/components/round-form-fields/round-form-fields.component.html
+++ b/src/app/components/round-form-fields/round-form-fields.component.html
@@ -100,6 +100,7 @@
       inputmode="numeric"
       [min]="host.minGrossScore"
       [max]="host.maxGrossScore"
+      autocomplete="off"
       class="w-full bg-surface border border-borders rounded-xl px-4 py-3 text-base text-primary-font focus:outline-none focus:border-primary-light box-border"
       [appValidationStatus]="host.submitCount"
     />

--- a/src/app/components/round-form-fields/round-form-fields.component.html
+++ b/src/app/components/round-form-fields/round-form-fields.component.html
@@ -100,7 +100,6 @@
       inputmode="numeric"
       [min]="host.minGrossScore"
       [max]="host.maxGrossScore"
-      autocomplete="off"
       class="w-full bg-surface border border-borders rounded-xl px-4 py-3 text-base text-primary-font focus:outline-none focus:border-primary-light box-border"
       [appValidationStatus]="host.submitCount"
     />

--- a/src/app/components/tee-form/tee-form.component.html
+++ b/src/app/components/tee-form/tee-form.component.html
@@ -7,8 +7,7 @@
       class="w-full bg-background border border-borders rounded-xl px-4 py-3 text-base text-primary-font focus:outline-none focus:border-primary-light box-border"
       [appValidationStatus]="submitCount"
       type="text"
-      autocomplete="off"
-      title="Tee name"
+      aria-label="Tee name"
     />
   </div>
 
@@ -25,8 +24,7 @@
         type="number"
         inputmode="decimal"
         step="0.1"
-        autocomplete="off"
-        title="Course rating"
+        aria-label="Course rating"
       />
     </div>
 
@@ -41,8 +39,7 @@
         [appValidationStatus]="submitCount"
         type="number"
         inputmode="numeric"
-        autocomplete="off"
-        title="Slope rating"
+        aria-label="Slope rating"
       />
     </div>
 
@@ -55,8 +52,7 @@
         [appValidationStatus]="submitCount"
         type="number"
         inputmode="numeric"
-        autocomplete="off"
-        title="Par"
+        aria-label="Par"
       />
     </div>
   </div>

--- a/src/app/components/tee-form/tee-form.component.html
+++ b/src/app/components/tee-form/tee-form.component.html
@@ -8,6 +8,7 @@
       [appValidationStatus]="submitCount"
       type="text"
       autocomplete="off"
+      title="Tee name"
     />
   </div>
 
@@ -25,6 +26,7 @@
         inputmode="decimal"
         step="0.1"
         autocomplete="off"
+        title="Course rating"
       />
     </div>
 
@@ -40,6 +42,7 @@
         type="number"
         inputmode="numeric"
         autocomplete="off"
+        title="Slope rating"
       />
     </div>
 
@@ -53,6 +56,7 @@
         type="number"
         inputmode="numeric"
         autocomplete="off"
+        title="Par"
       />
     </div>
   </div>

--- a/src/app/components/tee-form/tee-form.component.html
+++ b/src/app/components/tee-form/tee-form.component.html
@@ -7,6 +7,7 @@
       class="w-full bg-background border border-borders rounded-xl px-4 py-3 text-base text-primary-font focus:outline-none focus:border-primary-light box-border"
       [appValidationStatus]="submitCount"
       type="text"
+      autocomplete="off"
     />
   </div>
 
@@ -23,6 +24,7 @@
         type="number"
         inputmode="decimal"
         step="0.1"
+        autocomplete="off"
       />
     </div>
 
@@ -37,6 +39,7 @@
         [appValidationStatus]="submitCount"
         type="number"
         inputmode="numeric"
+        autocomplete="off"
       />
     </div>
 
@@ -49,6 +52,7 @@
         [appValidationStatus]="submitCount"
         type="number"
         inputmode="numeric"
+        autocomplete="off"
       />
     </div>
   </div>

--- a/src/app/pages/add-round/add-round.component.html
+++ b/src/app/pages/add-round/add-round.component.html
@@ -3,7 +3,7 @@
 
   <main class="flex-1 overflow-y-auto">
     <div class="px-4 py-6 h-full">
-      <form [formGroup]="roundForm" (ngSubmit)="onSubmit()" class="flex flex-col gap-8">
+      <form [formGroup]="roundForm" (ngSubmit)="onSubmit()" autocomplete="off" class="flex flex-col gap-8">
         <app-round-form-fields [host]="this">
           <button
             courseAction

--- a/src/app/pages/course-detail/course-detail.component.html
+++ b/src/app/pages/course-detail/course-detail.component.html
@@ -46,7 +46,7 @@
 
         <div class="bg-surface rounded-2xl p-5">
           <h2 class="text-lg font-medium text-primary-font mb-6 mt-0">Add tee</h2>
-          <form [formGroup]="teeForm" (ngSubmit)="onAddTeeSubmit()" class="flex flex-col gap-5">
+          <form [formGroup]="teeForm" (ngSubmit)="onAddTeeSubmit()" autocomplete="off" class="flex flex-col gap-5">
             <app-tee-form [parentForm]="teeForm" [submitCount]="teeSubmitCount"></app-tee-form>
 
             <button

--- a/src/app/pages/edit-round/edit-round.component.html
+++ b/src/app/pages/edit-round/edit-round.component.html
@@ -3,7 +3,7 @@
 
   <main class="flex-1 overflow-y-auto">
     <div class="px-4 py-6 h-full">
-      <form [formGroup]="roundForm" (ngSubmit)="onSubmit()" class="flex flex-col gap-8">
+      <form [formGroup]="roundForm" (ngSubmit)="onSubmit()" autocomplete="off" class="flex flex-col gap-8">
         <app-round-form-fields [host]="this"></app-round-form-fields>
 
         <div class="pb-6">


### PR DESCRIPTION
This pull request improves user experience and data entry consistency by adding the `autocomplete="off"` attribute to various input fields across multiple form components. This change ensures that browsers do not suggest previously entered values, which is especially important for sensitive or frequently changing form data. Additionally, some fields in the `tee-form` component now have descriptive `title` attributes to enhance accessibility.

The most important changes include:

**Form input improvements:**

* Added `autocomplete="off"` to all relevant input fields in the following components to prevent browsers from autofilling or suggesting previous entries:
  - `add-course-modal.component.html` [[1]](diffhunk://#diff-3ad0461dcff2b509f0689245a93468608fa1258a159368bdcfda1479ce212bd4R16) [[2]](diffhunk://#diff-3ad0461dcff2b509f0689245a93468608fa1258a159368bdcfda1479ce212bd4R34) [[3]](diffhunk://#diff-3ad0461dcff2b509f0689245a93468608fa1258a159368bdcfda1479ce212bd4R49) [[4]](diffhunk://#diff-3ad0461dcff2b509f0689245a93468608fa1258a159368bdcfda1479ce212bd4R62) [[5]](diffhunk://#diff-3ad0461dcff2b509f0689245a93468608fa1258a159368bdcfda1479ce212bd4R75)
  - `edit-course-modal.component.html`
  - `round-form-fields.component.html`
  - `tee-form.component.html` [[1]](diffhunk://#diff-d56428f7c7dd3333eeb393638276564662414154c17cf693910dc368a33bb2feR10-R11) [[2]](diffhunk://#diff-d56428f7c7dd3333eeb393638276564662414154c17cf693910dc368a33bb2feR28-R29) [[3]](diffhunk://#diff-d56428f7c7dd3333eeb393638276564662414154c17cf693910dc368a33bb2feR44-R45) [[4]](diffhunk://#diff-d56428f7c7dd3333eeb393638276564662414154c17cf693910dc368a33bb2feR58-R59)

**Accessibility enhancements:**

* Added `title` attributes to inputs in `tee-form.component.html` for better accessibility and context for users:
  - Tee name, Course rating, Slope rating, and Par fields now have descriptive titles. [[1]](diffhunk://#diff-d56428f7c7dd3333eeb393638276564662414154c17cf693910dc368a33bb2feR10-R11) [[2]](diffhunk://#diff-d56428f7c7dd3333eeb393638276564662414154c17cf693910dc368a33bb2feR28-R29) [[3]](diffhunk://#diff-d56428f7c7dd3333eeb393638276564662414154c17cf693910dc368a33bb2feR44-R45) [[4]](diffhunk://#diff-d56428f7c7dd3333eeb393638276564662414154c17cf693910dc368a33bb2feR58-R59)